### PR TITLE
調査: Dredd 設定によるバリデーション厳密性向上の可能性

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -75,6 +75,7 @@ components:
           example: "Optional item description"
     Item:
       type: object
+      additionalProperties: false # Ensure this is set
       required:
         - id
         - name

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dredd API testing sample",
   "main": "server.js",
   "scripts": {
-    "test": "dredd openapi.yaml http://localhost:3000 --hooks=hooks.js --loglevel=error",
+    "test": "dredd openapi.yaml http://localhost:3000 --loglevel=error",
     "start": "node server.js",
     "dev": "python3 -m uvicorn main:app --reload --port 3000"
   },


### PR DESCRIPTION
## 検証: Dredd 標準機能における `$ref` + `additionalProperties: false` の制約検証

### 目的

Issue #2 の調査で判明した「Dredd の標準機能では、OpenAPI 仕様で `$ref` を介して参照されるスキーマに定義された `additionalProperties: false` 制約を検証できない」という仮説を、実際のコード変更とテスト実行によって検証します。

### 変更内容

1.  **API の変更 ([main.py](cci:7://file:///Users/seiya_shimizu/Documents/API%E3%83%86%E3%82%B9%E3%83%88%E8%87%AA%E5%8B%95%E5%8C%96%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB/Dredd/main.py:0:0-0:0))**:
    *   `GET /items` エンドポイントが、OpenAPI 仕様 (`components/schemas/Item`) に定義されていない `extra_field` を意図的に含むレスポンスを返すように変更しました。
    *   テストのため、`@app.get("/items")` デコレーターから `response_model=List[Item]` を一時的に削除しました。
2.  **OpenAPI 仕様の変更 (`openapi.yaml`)**:
    *   `components/schemas/Item` に `additionalProperties: false` を追加しました (master ブランチには未反映だったため)。これにより、[Item](cci:2://file:///Users/seiya_shimizu/Documents/API%E3%83%86%E3%82%B9%E3%83%88%E8%87%AA%E5%8B%95%E5%8C%96%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB/Dredd/main.py:24:0-28:113) スキーマは定義済みのプロパティ (`id`, `name`, `description`, `createdAt`) 以外を許可しない、という仕様になります。
3.  **Dredd 実行設定の変更 (`package.json`)**:
    *   `scripts.test` から `--hooks hooks.js` オプションを一時的に削除し、フックによるカスタム検証が無効な状態で Dredd が実行されるようにしました。

### 実験結果

*   FastAPI サーバーを起動 (`npm run dev`)。
*   フックを無効にした状態で Dredd テストを実行 (`npm test`)。
*   **結果:** `GET /items` API が仕様外の `extra_field` を返しているにも関わらず、Dredd のテストは **`pass`** しました。
